### PR TITLE
Add UninstallAsync method to uninstall flux

### DIFF
--- a/Devantler.FluxCLI.Tests/FluxTests/AllMethodsTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/AllMethodsTests.cs
@@ -31,6 +31,7 @@ public class AllMethodsTests
     await Flux.ReconcileKustomizationAsync("podinfo", withSource: true, cancellationToken: cancellationToken);
 
     // Cleanup
+    await Flux.UninstallAsync(cancellationToken: cancellationToken);
     await Kind.DeleteClusterAsync(clusterName, CancellationToken.None);
   }
 }

--- a/Devantler.FluxCLI.Tests/FluxTests/AllMethodsTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/AllMethodsTests.cs
@@ -22,7 +22,7 @@ public class AllMethodsTests
     var cancellationToken = new CancellationToken();
 
     // Act
-    await Kind.DeleteClusterAsync(clusterName, CancellationToken.None);
+    await Kind.DeleteClusterAsync(clusterName, cancellationToken);
     await Kind.CreateClusterAsync(clusterName, configPath, cancellationToken);
     await Flux.InstallAsync(cancellationToken: cancellationToken);
     await Flux.CreateOCISourceAsync("podinfo", new Uri("oci://ghcr.io/stefanprodan/manifests/podinfo"));
@@ -32,6 +32,6 @@ public class AllMethodsTests
 
     // Cleanup
     await Flux.UninstallAsync(cancellationToken: cancellationToken);
-    await Kind.DeleteClusterAsync(clusterName, CancellationToken.None);
+    await Kind.DeleteClusterAsync(clusterName, cancellationToken);
   }
 }

--- a/Devantler.FluxCLI.Tests/FluxTests/UninstallAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/UninstallAsyncTests.cs
@@ -1,0 +1,22 @@
+namespace Devantler.FluxCLI.Tests.FluxTests;
+
+/// <summary>
+/// Tests for the <see cref="Flux.UninstallAsync(string, CancellationToken)"/> method.
+/// </summary>
+[Collection("Flux")]
+public class UninstallAsyncTests
+{
+  /// <summary>
+  /// Test to verify that the method throws an <see cref="InvalidOperationException" /> when no cluster is configured.
+  /// </summary>
+  /// <returns></returns>
+  [Fact]
+  public async Task UninstallAsync_ThrowsInvalidOperationException_WhenNoClusterIsConfigured()
+  {
+    // Act
+    var exception = await Record.ExceptionAsync(async () => await Flux.UninstallAsync().ConfigureAwait(false));
+
+    // Assert
+    _ = Assert.IsType<InvalidOperationException>(exception);
+  }
+}

--- a/Devantler.FluxCLI/Flux.cs
+++ b/Devantler.FluxCLI/Flux.cs
@@ -66,7 +66,7 @@ public static class Flux
       Command.WithArguments(["uninstall", "--silent"]) :
       Command.WithArguments(["uninstall", "--silent", "--context", context]);
     var (exitCode, message) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
-    if (exitCode != 0)
+    if (exitCode != 0 || message.Contains("connection refused", StringComparison.OrdinalIgnoreCase))
     {
       throw new InvalidOperationException($"Failed to uninstall flux: {message}");
     }

--- a/Devantler.FluxCLI/Flux.cs
+++ b/Devantler.FluxCLI/Flux.cs
@@ -63,8 +63,8 @@ public static class Flux
   public static async Task UninstallAsync(string? context = default, CancellationToken cancellationToken = default)
   {
     var command = string.IsNullOrEmpty(context) ?
-      Command.WithArguments(["uninstall"]) :
-      Command.WithArguments(["uninstall", "--context", context]);
+      Command.WithArguments(["uninstall", "--silent"]) :
+      Command.WithArguments(["uninstall", "--silent", "--context", context]);
     var (exitCode, message) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {

--- a/Devantler.FluxCLI/Flux.cs
+++ b/Devantler.FluxCLI/Flux.cs
@@ -36,7 +36,7 @@ public static class Flux
   }
 
   /// <summary>
-  /// Installs flux in the specified context.
+  /// Installs flux.
   /// </summary>
   /// <param name="context"></param>
   /// <param name="cancellationToken"></param>
@@ -50,6 +50,25 @@ public static class Flux
     if (exitCode != 0)
     {
       throw new InvalidOperationException($"Failed to install flux: {message}");
+    }
+  }
+
+  /// <summary>
+  /// Uninstalls flux.
+  /// </summary>
+  /// <param name="context"></param>
+  /// <param name="cancellationToken"></param>
+  /// <returns></returns>
+  /// <exception cref="InvalidOperationException"></exception>
+  public static async Task UninstallAsync(string? context = default, CancellationToken cancellationToken = default)
+  {
+    var command = string.IsNullOrEmpty(context) ?
+      Command.WithArguments(["uninstall"]) :
+      Command.WithArguments(["uninstall", "--context", context]);
+    var (exitCode, message) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
+    if (exitCode != 0)
+    {
+      throw new InvalidOperationException($"Failed to uninstall flux: {message}");
     }
   }
 


### PR DESCRIPTION
This pull request adds a new method, `UninstallAsync`, to the `Flux` class. The method allows for the uninstallation of flux. It includes a test to verify that the method throws an `InvalidOperationException` when no cluster is configured.