### PR TITLE
Add FluxException class for error handling

### DIFF
--- a/Devantler.FluxCLI.Tests/FluxExceptionTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxExceptionTests.cs
@@ -1,0 +1,55 @@
+namespace Devantler.FluxCLI.Tests;
+
+/// <summary>
+/// Tests for the <see cref="FluxException"/> class.
+/// </summary>
+public class FluxExceptionTests
+{
+  /// <summary>
+  /// Tests the default constructor.
+  /// </summary>
+  [Fact]
+  public void Constructor_GivenNothing_CallsDefaultConstructor()
+  {
+    // Act
+    var exception = new FluxException();
+
+    // Assert
+    Assert.NotNull(exception);
+  }
+
+  /// <summary>
+  /// Tests the constructor with a message.
+  /// </summary>
+  [Fact]
+  public void Constructor_GivenMessage_SetsMessageProperty()
+  {
+    // Arrange
+    string message = "Test message";
+
+    // Act
+    var exception = new FluxException(message);
+
+    // Assert
+    Assert.Equal(message, exception.Message);
+  }
+
+  /// <summary>
+  /// Tests the constructor with a message and inner exception.
+  /// </summary>
+  [Fact]
+  public void Constructor_GivenMessageAndInnerException_SetsMessageAndInnerExceptionProperties()
+  {
+    // Arrange
+    string message = "Test message";
+    var innerException = new NotImplementedException();
+
+    // Act
+    var exception = new FluxException(message, innerException);
+
+    // Assert
+    Assert.Equal(message, exception.Message);
+    Assert.Equal(innerException, exception.InnerException);
+  }
+}
+

--- a/Devantler.FluxCLI.Tests/FluxTests/CreateKustomizationAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/CreateKustomizationAsyncTests.cs
@@ -17,6 +17,6 @@ public class CreateKustomizationAsyncTests
     var exception = await Record.ExceptionAsync(async () => await Flux.CreateKustomizationAsync("test", "test", "test").ConfigureAwait(false));
 
     // Assert
-    _ = Assert.IsType<InvalidOperationException>(exception);
+    _ = Assert.IsType<FluxException>(exception);
   }
 }

--- a/Devantler.FluxCLI.Tests/FluxTests/CreateOCISourceAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/CreateOCISourceAsyncTests.cs
@@ -18,6 +18,6 @@ public class CreateOCISourceAsyncTests
     var exception = await Record.ExceptionAsync(async () => await Flux.CreateOCISourceAsync("test", new Uri("http://test")).ConfigureAwait(false));
 
     // Assert
-    _ = Assert.IsType<InvalidOperationException>(exception);
+    _ = Assert.IsType<FluxException>(exception);
   }
 }

--- a/Devantler.FluxCLI.Tests/FluxTests/InstallAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/InstallAsyncTests.cs
@@ -17,6 +17,6 @@ public class InstallAsyncTests
     var exception = await Record.ExceptionAsync(async () => await Flux.InstallAsync().ConfigureAwait(false));
 
     // Assert
-    _ = Assert.IsType<InvalidOperationException>(exception);
+    _ = Assert.IsType<FluxException>(exception);
   }
 }

--- a/Devantler.FluxCLI.Tests/FluxTests/PushArtifactAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/PushArtifactAsyncTests.cs
@@ -44,6 +44,6 @@ public class PushArtifactAsyncTests
     var exception = await Record.ExceptionAsync(async () => await Flux.PushArtifactAsync(new Uri("oci://localhost:5555/test-artifact"), "./Devantler.FluxCLI.Tests/assets", cancellationToken: new CancellationToken()).ConfigureAwait(false));
 
     // Assert
-    _ = Assert.IsType<InvalidOperationException>(exception);
+    _ = Assert.IsType<FluxException>(exception);
   }
 }

--- a/Devantler.FluxCLI.Tests/FluxTests/ReconcileHelmReleaseAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/ReconcileHelmReleaseAsyncTests.cs
@@ -17,6 +17,6 @@ public class ReconcileHelmReleaseAsyncTests
     var exception = await Record.ExceptionAsync(async () => await Flux.ReconcileHelmReleaseAsync("test").ConfigureAwait(false));
 
     // Assert
-    _ = Assert.IsType<InvalidOperationException>(exception);
+    _ = Assert.IsType<FluxException>(exception);
   }
 }

--- a/Devantler.FluxCLI.Tests/FluxTests/ReconcileKustomizationAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/ReconcileKustomizationAsyncTests.cs
@@ -17,6 +17,6 @@ public class ReconcileKustomizationAsyncTests
     var exception = await Record.ExceptionAsync(async () => await Flux.ReconcileKustomizationAsync("test").ConfigureAwait(false));
 
     // Assert
-    _ = Assert.IsType<InvalidOperationException>(exception);
+    _ = Assert.IsType<FluxException>(exception);
   }
 }

--- a/Devantler.FluxCLI.Tests/FluxTests/ReconcileOCISourceAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/ReconcileOCISourceAsyncTests.cs
@@ -17,6 +17,6 @@ public class ReconcileOCISourceAsyncTests
     var exception = await Record.ExceptionAsync(async () => await Flux.ReconcileOCISourceAsync("test").ConfigureAwait(false));
 
     // Assert
-    _ = Assert.IsType<InvalidOperationException>(exception);
+    _ = Assert.IsType<FluxException>(exception);
   }
 }

--- a/Devantler.FluxCLI.Tests/FluxTests/UninstallAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/UninstallAsyncTests.cs
@@ -17,6 +17,6 @@ public class UninstallAsyncTests
     var exception = await Record.ExceptionAsync(async () => await Flux.UninstallAsync().ConfigureAwait(false));
 
     // Assert
-    _ = Assert.IsType<InvalidOperationException>(exception);
+    _ = Assert.IsType<FluxException>(exception);
   }
 }

--- a/Devantler.FluxCLI/Flux.cs
+++ b/Devantler.FluxCLI/Flux.cs
@@ -47,10 +47,10 @@ public static class Flux
   {
     var command = string.IsNullOrEmpty(context) ? Command.WithArguments(["install"]) :
       Command.WithArguments(["install", "--context", context]);
-    var (exitCode, message) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
+    var (exitCode, _) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
-      throw new InvalidOperationException($"Failed to install flux: {message}");
+      throw new FluxException($"Failed to install flux");
     }
   }
 
@@ -69,7 +69,7 @@ public static class Flux
     var (exitCode, message) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0 || message.Contains("connection refused", StringComparison.OrdinalIgnoreCase))
     {
-      throw new InvalidOperationException($"Failed to uninstall flux: {message}");
+      throw new FluxException($"Failed to uninstall flux");
     }
   }
 
@@ -95,10 +95,10 @@ public static class Flux
       Command.WithArguments(
         ["create", "source", "oci", name, "--url", url.ToString(), "--tag", tag, "--interval", interval, "--namespace", @namespace, "--context", context]
       );
-    var (exitCode, message) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
+    var (exitCode, _) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
-      throw new InvalidOperationException($"Failed to create OCI source: {message}");
+      throw new FluxException($"Failed to create OCI source");
     }
   }
 
@@ -125,10 +125,10 @@ public static class Flux
       Command.WithArguments(
         ["create", "kustomization", name, "--source", source, "--path", path, "--namespace", @namespace, "--target-namespace", @namespace, "--interval", interval, "--prune", prune.ToString(), "--wait", wait.ToString(), "--depends-on", dependsOn != null ? string.Join(",", dependsOn) : "", "--context", context]
       );
-    var (exitCode, message) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
+    var (exitCode, _) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
-      throw new InvalidOperationException($"Failed to create Kustomization: {message}");
+      throw new FluxException($"Failed to create Kustomization");
     }
   }
 
@@ -148,10 +148,10 @@ public static class Flux
       Command.WithArguments(
         ["reconcile", "source", "oci", name, "--namespace", @namespace, "--context", context]
       );
-    var (exitCode, message) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
+    var (exitCode, _) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
-      throw new InvalidOperationException($"Failed to reconcile OCI source: {message}");
+      throw new FluxException($"Failed to reconcile OCI source");
     }
   }
 
@@ -172,10 +172,10 @@ public static class Flux
       Command.WithArguments(
         ["reconcile", "kustomization", name, "--namespace", @namespace, "--with-source", withSource.ToString(), "--context", context]
       );
-    var (exitCode, message) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
+    var (exitCode, _) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
-      throw new InvalidOperationException($"Failed to reconcile Kustomization: {message}");
+      throw new InvalidOperationException($"Failed to reconcile Kustomization");
     }
   }
 
@@ -198,10 +198,10 @@ public static class Flux
       Command.WithArguments(
         ["reconcile", "helmrelease", name, "--namespace", @namespace, "--with-source", withSource.ToString(), "--force", force.ToString(), "--reset", reset.ToString(), "--context", context]
       );
-    var (exitCode, message) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
+    var (exitCode, _) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
-      throw new InvalidOperationException($"Failed to reconcile HelmRelease: {message}");
+      throw new InvalidOperationException($"Failed to reconcile HelmRelease");
     }
   }
 
@@ -233,19 +233,19 @@ public static class Flux
     var pushCommand = Command.WithArguments(
       ["push", "artifact", $"{registry}:{currentTimeEpoch}", "--path", path, "--source", source, "--revision", revision]
     );
-    var (exitCode, message) = await CLI.RunAsync(pushCommand, cancellationToken: cancellationToken).ConfigureAwait(false);
+    var (exitCode, _) = await CLI.RunAsync(pushCommand, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
-      throw new InvalidOperationException($"Failed to push artifact: {message}");
+      throw new FluxException($"Failed to push artifact");
     }
 
     var tagCommand = Command.WithArguments(
       ["tag", "artifact", $"{registry}:{currentTimeEpoch}", "--tag", "latest"]
     );
-    (exitCode, message) = await CLI.RunAsync(tagCommand, cancellationToken: cancellationToken).ConfigureAwait(false);
+    (exitCode, _) = await CLI.RunAsync(tagCommand, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
-      throw new InvalidOperationException($"Failed to tag artifact: {message}");
+      throw new FluxException($"Failed to tag artifact");
     }
   }
 }

--- a/Devantler.FluxCLI/Flux.cs
+++ b/Devantler.FluxCLI/Flux.cs
@@ -42,7 +42,7 @@ public static class Flux
   /// <param name="context"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  /// <exception cref="InvalidOperationException"></exception>
+  /// <exception cref="FluxException"></exception>
   public static async Task InstallAsync(string? context = default, CancellationToken cancellationToken = default)
   {
     var command = string.IsNullOrEmpty(context) ? Command.WithArguments(["install"]) :
@@ -60,7 +60,7 @@ public static class Flux
   /// <param name="context"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  /// <exception cref="InvalidOperationException"></exception>
+  /// <exception cref="FluxException"></exception>
   public static async Task UninstallAsync(string? context = default, CancellationToken cancellationToken = default)
   {
     var command = string.IsNullOrEmpty(context) ?
@@ -84,7 +84,7 @@ public static class Flux
   /// <param name="interval"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  /// <exception cref="InvalidOperationException"></exception>
+  /// <exception cref="FluxException"></exception>
   public static async Task CreateOCISourceAsync(string name, Uri url, string? context = default, string @namespace = "flux-system", string tag = "latest", string interval = "10m", CancellationToken cancellationToken = default)
   {
     ArgumentNullException.ThrowIfNull(url, nameof(url));
@@ -175,7 +175,7 @@ public static class Flux
     var (exitCode, _) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
-      throw new InvalidOperationException($"Failed to reconcile Kustomization");
+      throw new FluxException($"Failed to reconcile Kustomization");
     }
   }
 
@@ -201,7 +201,7 @@ public static class Flux
     var (exitCode, _) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
-      throw new InvalidOperationException($"Failed to reconcile HelmRelease");
+      throw new FluxException($"Failed to reconcile HelmRelease");
     }
   }
 

--- a/Devantler.FluxCLI/FluxException.cs
+++ b/Devantler.FluxCLI/FluxException.cs
@@ -1,0 +1,32 @@
+namespace Devantler.FluxCLI;
+
+/// <summary>
+/// An exception thrown by the Flux CLI.
+/// </summary>
+[Serializable]
+public class FluxException : Exception
+{
+  /// <summary>
+  /// Initializes a new instance of the <see cref="FluxException"/> class.
+  /// </summary>
+  public FluxException()
+  {
+  }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="FluxException"/> class with a specified error message.
+  /// </summary>
+  /// <param name="message"></param>
+  public FluxException(string? message) : base(message)
+  {
+  }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="FluxException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+  /// </summary>
+  /// <param name="message"></param>
+  /// <param name="innerException"></param>
+  public FluxException(string? message, Exception? innerException) : base(message, innerException)
+  {
+  }
+}


### PR DESCRIPTION
Introduce the `FluxException` class to provide a specific exception type for the Flux CLI, along with unit tests to validate its behavior. Update existing error handling to use `FluxException` instead of `InvalidOperationException`.