### PR TITLE
Add 'insecure' parameter to CreateOCISourceAsync method

### DIFF
--- a/Devantler.FluxCLI.Tests/FluxTests/CreateOCISourceAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/CreateOCISourceAsyncTests.cs
@@ -1,7 +1,7 @@
 namespace Devantler.FluxCLI.Tests.FluxTests;
 
 /// <summary>
-/// Tests for the <see cref="Flux.CreateOCISourceAsync(string, Uri, string, string, string, string, CancellationToken)"/> method.
+/// Tests for the <see cref="Flux.CreateOCISourceAsync(string, Uri, bool, string, string, string, string, CancellationToken)"/> method.
 /// </summary>
 [Collection("Flux")]
 public class CreateOCISourceAsyncTests
@@ -15,7 +15,7 @@ public class CreateOCISourceAsyncTests
   public async Task CreateOCISourceAsync_ThrowsInvalidOperationException_WhenNoClusterIsConfigured()
   {
     // Act
-    var exception = await Record.ExceptionAsync(async () => await Flux.CreateOCISourceAsync("test", new Uri("http://test")).ConfigureAwait(false));
+    var exception = await Record.ExceptionAsync(async () => await Flux.CreateOCISourceAsync("test", new Uri("http://test"), true).ConfigureAwait(false));
 
     // Assert
     _ = Assert.IsType<FluxException>(exception);

--- a/Devantler.FluxCLI/Flux.cs
+++ b/Devantler.FluxCLI/Flux.cs
@@ -79,21 +79,36 @@ public static class Flux
   /// <param name="context"></param>
   /// <param name="name"></param>
   /// <param name="url"></param>
+  /// <param name="insecure"></param>
   /// <param name="namespace"></param>
   /// <param name="tag"></param>
   /// <param name="interval"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
   /// <exception cref="FluxException"></exception>
-  public static async Task CreateOCISourceAsync(string name, Uri url, string? context = default, string @namespace = "flux-system", string tag = "latest", string interval = "10m", CancellationToken cancellationToken = default)
+  public static async Task CreateOCISourceAsync(string name, Uri url, bool insecure = false, string? context = default, string @namespace = "flux-system", string tag = "latest", string interval = "10m", CancellationToken cancellationToken = default)
   {
     ArgumentNullException.ThrowIfNull(url, nameof(url));
     var command = string.IsNullOrEmpty(context) ?
       Command.WithArguments(
-        ["create", "source", "oci", name, "--url", url.ToString(), "--tag", tag, "--interval", interval, "--namespace", @namespace]
+        [
+          "create", "source", "oci", name,
+          "--url", url.ToString(),
+          "--insecure", insecure.ToString(),
+          "--tag", tag,
+          "--interval", interval,
+          "--namespace", @namespace
+        ]
       ) :
       Command.WithArguments(
-        ["create", "source", "oci", name, "--url", url.ToString(), "--tag", tag, "--interval", interval, "--namespace", @namespace, "--context", context]
+        [
+          "create", "source", "oci", name,
+          "--url", url.ToString(),
+          "--insecure", insecure.ToString(),
+          "--tag", tag,
+          "--interval", interval,
+          "--namespace", @namespace,
+          "--context", context]
       );
     var (exitCode, _) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)


### PR DESCRIPTION
Introduce an 'insecure' parameter to the CreateOCISourceAsync method to allow for insecure connections. Update tests to reflect this change.