### PR TITLE
Add timeout parameter to ReconcileKustomizationAsync method

### DIFF
--- a/Devantler.FluxCLI.Tests/FluxTests/ReconcileKustomizationAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/ReconcileKustomizationAsyncTests.cs
@@ -1,7 +1,7 @@
 namespace Devantler.FluxCLI.Tests.FluxTests;
 
 /// <summary>
-/// Tests for the <see cref="Flux.ReconcileKustomizationAsync(string, string, string, bool, CancellationToken)"/> method.
+/// Tests for the <see cref="Flux.ReconcileKustomizationAsync(string, string, string, bool, string, CancellationToken)"/> method.
 /// </summary>
 [Collection("Flux")]
 public class ReconcileKustomizationAsyncTests

--- a/Devantler.FluxCLI.Tests/FluxTests/ReconcileOCISourceAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/ReconcileOCISourceAsyncTests.cs
@@ -1,7 +1,7 @@
 namespace Devantler.FluxCLI.Tests.FluxTests;
 
 /// <summary>
-/// Tests for the <see cref="Flux.ReconcileOCISourceAsync(string, string, string, CancellationToken)"/> method.
+/// Tests for the <see cref="Flux.ReconcileOCISourceAsync(string, string, string, string, CancellationToken)"/> method.
 /// </summary>
 [Collection("Flux")]
 public class ReconcileOCISourceAsyncTests

--- a/Devantler.FluxCLI/Flux.cs
+++ b/Devantler.FluxCLI/Flux.cs
@@ -155,15 +155,16 @@ public static class Flux
   /// <param name="name"></param>
   /// <param name="context"></param>
   /// <param name="namespace"></param>
+  /// <param name="timeout"></param>
   /// <param name="cancellationToken"></param>
-  public static async Task ReconcileOCISourceAsync(string name, string? context = default, string @namespace = "flux-system", CancellationToken cancellationToken = default)
+  public static async Task ReconcileOCISourceAsync(string name, string? context = default, string @namespace = "flux-system", string timeout = "5m", CancellationToken cancellationToken = default)
   {
     var command = string.IsNullOrEmpty(context) ?
       Command.WithArguments(
-        ["reconcile", "source", "oci", name, "--namespace", @namespace]
+        ["reconcile", "source", "oci", name, "--namespace", @namespace, "--timeout", timeout]
       ) :
       Command.WithArguments(
-        ["reconcile", "source", "oci", name, "--namespace", @namespace, "--context", context]
+        ["reconcile", "source", "oci", name, "--namespace", @namespace, "--timeout", timeout, "--context", context]
       );
     var (exitCode, _) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)

--- a/Devantler.FluxCLI/Flux.cs
+++ b/Devantler.FluxCLI/Flux.cs
@@ -179,15 +179,16 @@ public static class Flux
   /// <param name="context"></param>
   /// <param name="namespace"></param>
   /// <param name="withSource"></param>
+  /// <param name="timeout"></param>
   /// <param name="cancellationToken"></param>
-  public static async Task ReconcileKustomizationAsync(string name, string? context = default, string @namespace = "flux-system", bool withSource = false, CancellationToken cancellationToken = default)
+  public static async Task ReconcileKustomizationAsync(string name, string? context = default, string @namespace = "flux-system", bool withSource = false, string timeout = "5m", CancellationToken cancellationToken = default)
   {
     var command = string.IsNullOrEmpty(context) ?
       Command.WithArguments(
-        ["reconcile", "kustomization", name, "--namespace", @namespace, "--with-source", withSource.ToString()]
+        ["reconcile", "kustomization", name, "--namespace", @namespace, "--with-source", withSource.ToString(), "--timeout", timeout]
       ) :
       Command.WithArguments(
-        ["reconcile", "kustomization", name, "--namespace", @namespace, "--with-source", withSource.ToString(), "--context", context]
+        ["reconcile", "kustomization", name, "--namespace", @namespace, "--with-source", withSource.ToString(), "--timeout", timeout, "--context", context]
       );
     var (exitCode, _) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)

--- a/Devantler.FluxCLI/Flux.cs
+++ b/Devantler.FluxCLI/Flux.cs
@@ -185,10 +185,10 @@ public static class Flux
   {
     var command = string.IsNullOrEmpty(context) ?
       Command.WithArguments(
-        ["reconcile", "kustomization", name, "--namespace", @namespace, "--with-source", withSource.ToString(), "--timeout", timeout]
+        ["reconcile", "kustomization", name, "--namespace", @namespace, $"--with-source={withSource}", "--timeout", timeout]
       ) :
       Command.WithArguments(
-        ["reconcile", "kustomization", name, "--namespace", @namespace, "--with-source", withSource.ToString(), "--timeout", timeout, "--context", context]
+        ["reconcile", "kustomization", name, "--namespace", @namespace, $"--with-source={withSource}", "--timeout", timeout, "--context", context]
       );
     var (exitCode, _) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)


### PR DESCRIPTION
Include a timeout parameter in the ReconcileKustomizationAsync method to enhance command execution control. Update tests accordingly.