### PR TITLE
Refactor tests by removing unused Kubernetes and Docker dependencies

### DIFF
--- a/Devantler.FluxCLI.Tests/Devantler.FluxCLI.Tests.csproj
+++ b/Devantler.FluxCLI.Tests/Devantler.FluxCLI.Tests.csproj
@@ -16,8 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.3" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.0.*" />
-    <PackageReference Include="Devantler.ContainerEngineProvisioner.Docker" Version="1.0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
@@ -25,10 +23,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Devantler.FluxCLI\Devantler.FluxCLI.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="assets/kind-config.yaml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Devantler.FluxCLI.Tests/assets/kind-config.yaml
+++ b/Devantler.FluxCLI.Tests/assets/kind-config.yaml
@@ -1,2 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4


### PR DESCRIPTION
Eliminate unnecessary dependencies related to Kubernetes and Docker from the test project to streamline the codebase.