### PR TITLE
Refactor RunAsync method to rename message to output

### DIFF
--- a/Devantler.FluxCLI.Tests/FluxTests/RunAsyncTests.cs
+++ b/Devantler.FluxCLI.Tests/FluxTests/RunAsyncTests.cs
@@ -15,10 +15,10 @@ public class RunAsyncTests
   public async Task RunAsync_Version_ReturnsVersion()
   {
     // Act
-    var (exitCode, message) = await Flux.RunAsync(["--version"]);
+    var (exitCode, output) = await Flux.RunAsync(["--version"]);
 
     // Assert
     Assert.Equal(0, exitCode);
-    Assert.Matches(@"^flux version \d+\.\d+\.\d+$", message.Trim());
+    Assert.Matches(@"^flux version \d+\.\d+\.\d+$", output.Trim());
   }
 }

--- a/Devantler.FluxCLI/Flux.cs
+++ b/Devantler.FluxCLI/Flux.cs
@@ -94,8 +94,8 @@ public static class Flux
     var command = string.IsNullOrEmpty(context) ?
       Command.WithArguments(["uninstall", "--silent"]) :
       Command.WithArguments(["uninstall", "--silent", "--context", context]);
-    var (exitCode, message) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
-    if (exitCode != 0 || message.Contains("connection refused", StringComparison.OrdinalIgnoreCase))
+    var (exitCode, output) = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
+    if (exitCode != 0 || output.Contains("connection refused", StringComparison.OrdinalIgnoreCase))
     {
       throw new FluxException($"Failed to uninstall flux");
     }

--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ You can execute the Flux CLI commands using the `Flux` class.
 ```csharp
 using Devantler.FluxCLi;
 
-var (exitCode, message) = await Flux.RunAsync(["arg1", "arg2"]);
+var (exitCode, output) = await Flux.RunAsync(["arg1", "arg2"]);
 ```


### PR DESCRIPTION
Rename the variable `message` to `output` in the `RunAsync` method for clarity and update the README accordingly.